### PR TITLE
allow passing a custom normalization function to uwsgimemhog

### DIFF
--- a/pyuwsgimemhog/cli.py
+++ b/pyuwsgimemhog/cli.py
@@ -4,7 +4,7 @@
 import sys
 import click
 
-from .pyuwsgimemhog import uwsgimemhog
+from .pyuwsgimemhog import normalize_path, normalize_path_with_nums, uwsgimemhog
 
 
 @click.command()
@@ -17,8 +17,9 @@ from .pyuwsgimemhog import uwsgimemhog
               help='Normalize numbers in urls')
 def main(logfile, threshold, normalize_nums):
     """Console script for pyuwsgimemhog."""
+    normalize = normalize_path_with_nums if normalize_nums else normalize_path
     with open(logfile, "r") as f:
-        hogs = uwsgimemhog(f, threshold * 1_000_000, normalize_nums)
+        hogs = uwsgimemhog(f, threshold * 1_000_000, normalize)
         for path, memory, count in hogs:
             click.echo('{} {} {} {:.1f}'.format(
                 path, memory // 1_000_000, count, memory / count / 1_000_000

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     description="uWSGI log parser to find memory hogs",
     entry_points={

--- a/tests/test_pyuwsgimemhog.py
+++ b/tests/test_pyuwsgimemhog.py
@@ -37,13 +37,13 @@ def sample_log():
 
 
 def test_uwsgimemhog_skips_invalid_lines(invalid_sample_log):
-    data = pyuwsgimemhog.uwsgimemhog(invalid_sample_log, threshold=1, normalize_nums=True)
+    data = pyuwsgimemhog.uwsgimemhog(invalid_sample_log, threshold=1, normalize=pyuwsgimemhog.normalize_path_with_nums)
     with pytest.raises(StopIteration):
         next(data)
 
 
 def test_uwsgimemhog_normalize_paths_correctly(normalization_log):
-    data = pyuwsgimemhog.uwsgimemhog(normalization_log, threshold=1, normalize_nums=False)
+    data = pyuwsgimemhog.uwsgimemhog(normalization_log, threshold=1,  normalize=pyuwsgimemhog.normalize_path)
     assert next(data) == ('/api/12', 9801728, 1)
     assert next(data) == ('/api/11', 2097152, 1)
     with pytest.raises(StopIteration):
@@ -51,27 +51,27 @@ def test_uwsgimemhog_normalize_paths_correctly(normalization_log):
 
 
 def test_uwsgimemhog_normalize_nums_correctly(normalization_log):
-    data = pyuwsgimemhog.uwsgimemhog(normalization_log, threshold=1, normalize_nums=True)
+    data = pyuwsgimemhog.uwsgimemhog(normalization_log, threshold=1, normalize=pyuwsgimemhog.normalize_path_with_nums)
     assert next(data) == ('/api/0', 11898880, 2)
     with pytest.raises(StopIteration):
         next(data)
 
 
 def test_uwsgimemhog_ignores_negative_rss_diffs(memory_reduction_log):
-    data = pyuwsgimemhog.uwsgimemhog(memory_reduction_log, threshold=1, normalize_nums=True)
+    data = pyuwsgimemhog.uwsgimemhog(memory_reduction_log, threshold=1, normalize=pyuwsgimemhog.normalize_path_with_nums)
     with pytest.raises(StopIteration):
         next(data)
 
 
 def test_uwsgimemhog_sum_same_path_on_different_pids_correctly(sample_log):
-    data = pyuwsgimemhog.uwsgimemhog(sample_log, threshold=1, normalize_nums=True)
+    data = pyuwsgimemhog.uwsgimemhog(sample_log, threshold=1, normalize=pyuwsgimemhog.normalize_path_with_nums)
     assert next(data) == ('/', 3723264, 2)
     with pytest.raises(StopIteration):
         next(data)
 
 
 def test_uwsgimemhog_threshold_works_correctly(sample_log):
-    data = pyuwsgimemhog.uwsgimemhog(sample_log, threshold=10_000_000, normalize_nums=True)
+    data = pyuwsgimemhog.uwsgimemhog(sample_log, threshold=10_000_000, normalize=pyuwsgimemhog.normalize_path_with_nums)
     with pytest.raises(StopIteration):
         next(data)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, pyflakes
+envlist = py{36,37,38,39}, pyflakes
 
 [travis]
 python =
@@ -20,4 +20,4 @@ deps =
 ;     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
-    py.test --basetemp={envtmpdir}
+    py.test --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
This allows consumers to pass more aggressive normalization routines to uwsgimemhog if it is used as a library i.e reverse Django URLs to display resolved view functions instead of URLs.

```python
from django.urls import resolve
from pyuwsgimemhog.pyuwsgimemhog import *

def normalize(path):
    try:
        view = resolve(path)
        return f'{view.__module__}.{view.__qualname__}'
    except Exception:
        return normalize_path(path)

uwsgimemhog(f, threshold * 1_000_000, normalize)
```