### PR TITLE
update RegEx to require RSS in order to process the line

### DIFF
--- a/pyuwsgimemhog/pyuwsgimemhog.py
+++ b/pyuwsgimemhog/pyuwsgimemhog.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 
 UWSGI_LOG_RE = re.compile(
-    r'({rss usage: (?P<rss>\d+) bytes/\d+MB} )?\[pid: (?P<pid>\d+)\|app: .*\|req: .*\] '
+    r'{rss usage: (?P<rss>\d+) bytes/\d+MB} \[pid: (?P<pid>\d+)\|app: .*\|req: .*\] '
     r'(?P<client_ip>\d+.\d+.\d+.\d+) .* \[(?P<date>\w+ \w+\s+\d+ \d+:\d+:\d+ \d+)\] '
     r'(?P<verb>GET|POST|HEAD|PATCH|PUT|DELETE) (?P<path>/.*) => '
     r'generated \d+ bytes in (?P<time>\d+) msecs \(HTTP/\d.\d (?P<status_code>\d+)\)'


### PR DESCRIPTION
Running the script against an existing log file produces errors due to `None` being converted to an `int`

The RSS is marked as optional in the RegEx:
https://github.com/xrmx/pyuwsgimemhog/blob/dac943abab3e403a3b45e3a81d4f962db456f9db/pyuwsgimemhog/pyuwsgimemhog.py#L9-L14

But treated as required here:

https://github.com/xrmx/pyuwsgimemhog/blob/dac943abab3e403a3b45e3a81d4f962db456f9db/pyuwsgimemhog/pyuwsgimemhog.py#L33

The record should just be skipped and never recorded, right?